### PR TITLE
Select on knative labels

### DIFF
--- a/.tanzu/tanzu_tilt_extensions.py
+++ b/.tanzu/tanzu_tilt_extensions.py
@@ -1,0 +1,18 @@
+def tanzu_k8s_yaml(workload, run_image, yaml):
+
+  # 1. Create fake deployment
+  deployment_template = """
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {workload}-proxy
+  annotations:
+    run-image: {run_image}
+"""
+  deployment = deployment_template.format(workload=workload, run_image=run_image)
+  
+  k8s_yaml(blob(deployment))
+  k8s_kind('ConfigMap', image_json_path="{.metadata.annotations.run-image}")
+  k8s_resource(workload + '-proxy', port_forwards=["8080:8080"],
+              extra_pod_selectors=[{'serving.knative.dev/service' : workload}], discovery_strategy="selectors-only")

--- a/.tanzu/wait.sh
+++ b/.tanzu/wait.sh
@@ -2,4 +2,4 @@
 
 workload=$1
 while [[ -z $(kubectl get pod -o jsonpath='{.items[?(@.metadata.annotations.developer\.apps\.tanzu\.vmware\.com/image-source-digest=="'$(kubectl get imagerepository ${workload}-source -o=jsonpath='{.status.url}')'")].metadata.name}') ]]; do echo "waiting..." && sleep 10; done 
-kubectl wait pod --for=condition=ready -l carto.run/workload-name=$workload,app.kubernetes.io/part-of=$workload
+kubectl wait pod --for=condition=ready -l serving.knative.dev/service=$workload,app.kubernetes.io/part-of=$workload

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,7 @@
+load('.tanzu/tanzu_tilt_extensions.py', 'tanzu_k8s_yaml')
+
 custom_build('harbor-repo.vmware.com/tanzu_desktop/sample-app-java', 
-    "tanzu apps workload apply -f config/workload.yaml --local-path=. --yes && \
+    "tanzu apps workload apply -f config/workload.yaml --live-update --local-path=. --source-image=harbor-repo.vmware.com/tanzu_desktop/sample-app-java-souce --yes && \
     .tanzu/wait.sh sample-app-java",
   ['pom.xml', './target/classes'],
   live_update = [
@@ -8,6 +10,4 @@ custom_build('harbor-repo.vmware.com/tanzu_desktop/sample-app-java',
   skips_local_docker=True
 )
   
-k8s_yaml('./config/workload.yaml')
-k8s_kind('Workload', image_json_path='{.spec.params[?(@.name=="run-image")].value}')
-k8s_resource(workload='sample-app-java', extra_pod_selectors=[{'serving.knative.dev/service':'sample-app-java'}])
+tanzu_k8s_yaml('sample-app-java', 'harbor-repo.vmware.com/tanzu_desktop/sample-app-java', './config/workload.yaml')


### PR DESCRIPTION
When waiting for pod deployment select on knative label

- carto.run labels is also present on build pods and prevents waiting from ever exiting because pods never reach 1
- required by default supply chain
    
[TD-275](https://jira.eng.vmware.com/browse/TD-275)