### PR TITLE
Support backstage catalog listing:

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,13 +1,13 @@
 load('.tanzu/tanzu_tilt_extensions.py', 'tanzu_k8s_yaml')
 
 
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/sample-app-java-source')
+SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/tanzu-java-web-app-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 
-custom_build('your-registry.io/project/sample-app-java',
+custom_build('your-registry.io/project/tanzu-java-web-app',
     "tanzu apps workload apply -f config/workload.yaml --live-update \
       --local-path " + LOCAL_PATH + " --source-image " + SOURCE_IMAGE + " --yes && \
-    .tanzu/wait.sh sample-app-java",
+    .tanzu/wait.sh tanzu-java-web-app",
   ['pom.xml', './target/classes'],
   live_update = [
     sync('./target/classes', '/workspace/BOOT-INF/classes')
@@ -15,4 +15,4 @@ custom_build('your-registry.io/project/sample-app-java',
   skips_local_docker=True
 )
 
-tanzu_k8s_yaml('sample-app-java', 'your-registry.io/project/sample-app-java', './config/workload.yaml')
+tanzu_k8s_yaml('tanzu-java-web-app', 'your-registry.io/project/tanzu-java-web-app', './config/workload.yaml')

--- a/accelerator.yaml
+++ b/accelerator.yaml
@@ -23,7 +23,7 @@ engine:
     chain:
     - type: ReplaceText
       substitutions:
-      - text: sample-app-java
+      - text: tanzu-java-web-app
         with: "#artifactId"
     - type: ReplaceText
       substitutions:

--- a/config/workload.yaml
+++ b/config/workload.yaml
@@ -1,13 +1,14 @@
 apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
-  name: sample-app-java
+  name: tanzu-java-web-app
   labels:
     apps.tanzu.vmware.com/workload-type: web
+    app.kubernetes.io/part-of: tanzu-java-web-app
 spec:
   params:
     - name: run-image
-      value: your-registry.io/project/sample-app-java
+      value: your-registry.io/project/tanzu-java-web-app
   source:
     git:
       url: https://github.com/sample-accelerators/tanzu-java-web-app


### PR DESCRIPTION
- needs annotation `app.kubernetes.io/part-of` in workload
- align all names `sample-app-java` and `tanzu-java-web-app`
  to be the same (don't think that is needed really, but it would
   be less confusing to have only one name for referencing
  everything).

See: https://vmware.slack.com/archives/C01G0P79LSE/p1635358238031600?thread_ts=1635333832.024200&cid=C01G0P79LSE