### PR TITLE
Fix #19: Remove env.post support in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,5 @@ management:
       exposure:
         include: "*"  
   endpoint:
-    env:
-      post:
-        enabled: true
     health:
       show-details: always


### PR DESCRIPTION
It doesn't actually  work anyway unless you also add
spring-cloud dependency to the pom.