### PR TITLE
Enable HTTP Tracing in App Live View

### DIFF
--- a/src/main/java/com/example/springboot/Application.java
+++ b/src/main/java/com/example/springboot/Application.java
@@ -7,6 +7,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
+import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository;
 
 @SpringBootApplication
 public class Application {
@@ -29,5 +31,9 @@ public class Application {
 
 		};
 	}
-
+	
+    	@Bean
+	public HttpTraceRepository htttpTraceRepository() {
+		return new InMemoryHttpTraceRepository();
+	}
 }


### PR DESCRIPTION
Without specifically implementing an HttpTraceRepository @Bean, HTTP Traces in App Live View would return a 404 not found.