### PR TITLE
Protect against 2021 Dec Log4J2 zero-day vulns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<java.version>8</java.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 
 	<licenses>


### PR DESCRIPTION
Verified critical vulns existed before this log4j version pin. Verified vulns are no longer found when scanning binary and image using Anchore Grype scanner.